### PR TITLE
SW-232: fix template to include all 16 controls and external trigger

### DIFF
--- a/mcc/Template/README.md
+++ b/mcc/Template/README.md
@@ -14,13 +14,15 @@ Provided is a blank template for creating HDL files using the Moku Cloud Compile
 | InputC <small><br> (Moku:Pro only) | in | signed | 15 downto 0 |
 | InputD <small><br> (Moku:Pro only) | in | signed | 15 downto 0 |
 ||
+| ExtTrig <small><br> (Moku:Lab and Moku:Pro) | in | std_logic | - |
+||
 | OutputA | out | signed | 15 downto 0 |
 | OutputB | out | signed | 15 downto 0 |
-| OutputC <small><br> (Moku:Pro only) | out | signed | 15 downto 0 |
+| OutputC <small><br> (Moku:Go and Moku:Pro) | out | signed | 15 downto 0 |
 | OutputD <small><br> (Moku:Pro only) | out | signed | 15 downto 0 |
 ||
 | Control0 | in | std_logic_vector | 31 downto 0 |
 | Control1 | in | std_logic_vector | 31 downto 0 |
 | ... | ... | ... | ... |
-| Control9 | in | std_logic_vector | 31 downto 0 |
+| Control15 | in | std_logic_vector | 31 downto 0 |
 ||

--- a/mcc/Template/Top.vhd
+++ b/mcc/Template/Top.vhd
@@ -14,7 +14,7 @@ begin
     -- ___ <= Control1;
     -- ___ <= Control2;
     --      ...
-    -- ___ <= Control9;
+    -- ___ <= Control15;
 
     -- OutputA => ___;
     -- OutputB => ___;


### PR DESCRIPTION
External trigger missing from template and Controls were listed 0-9 instead of 0-15