### PR TITLE
Fix typo in NN example

### DIFF
--- a/neural-network/Anomaly_detection.ipynb
+++ b/neural-network/Anomaly_detection.ipynb
@@ -209,7 +209,7 @@
    "id": "5c2ffa48",
    "metadata": {},
    "source": [
-    "First, set up the folder structure for organizaing output data and define the filename for captured data frames"
+    "First, set up the folder structure for organizing output data and define the filename for captured data frames"
    ]
   },
   {


### PR DESCRIPTION
I noticed a tiny typo in our NN examples.