### PR TITLE
MINOR: Remove all instances of outputinterp in CustomInstrument examples

### DIFF
--- a/mc/Advanced/DCSequencer/Verilog/Top.v
+++ b/mc/Advanced/DCSequencer/Verilog/Top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Advanced/EventCounter/Verilog/Top.v
+++ b/mc/Advanced/EventCounter/Verilog/Top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Basic/Adder/Verilog/Adder.v
+++ b/mc/Basic/Adder/Verilog/Adder.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Basic/ClockDivider/Verilog/top.v
+++ b/mc/Basic/ClockDivider/Verilog/top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Basic/DIO/Verilog/DIO.v
+++ b/mc/Basic/DIO/Verilog/DIO.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Basic/RegGate/Verilog/RegGate.v
+++ b/mc/Basic/RegGate/Verilog/RegGate.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Basic/RegUse/Verilog/RegUse.v
+++ b/mc/Basic/RegUse/Verilog/RegUse.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Moderate/ArithmeticUnit/Verilog/Top.v
+++ b/mc/Moderate/ArithmeticUnit/Verilog/Top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Moderate/AverageAndMedian/MokuGo/Verilog/Top.v
+++ b/mc/Moderate/AverageAndMedian/MokuGo/Verilog/Top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Moderate/AverageAndMedian/MokuPro/Verilog/Top.v
+++ b/mc/Moderate/AverageAndMedian/MokuPro/Verilog/Top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Moderate/SweptPulse/MokuGo/Verilog/Top.v
+++ b/mc/Moderate/SweptPulse/MokuGo/Verilog/Top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Moderate/SweptPulse/MokuLab/Verilog/Top.v
+++ b/mc/Moderate/SweptPulse/MokuLab/Verilog/Top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );

--- a/mc/Moderate/SweptPulse/MokuPro/Verilog/Top.v
+++ b/mc/Moderate/SweptPulse/MokuPro/Verilog/Top.v
@@ -15,11 +15,6 @@ module CustomInstrument (
     output wire signed [15:0] outputc,
     output wire signed [15:0] outputd,
 
-    output wire outputinterpa,
-    output wire outputinterpb,
-    output wire outputinterpc,
-    output wire outputinterpd,
-
     input wire [31:0] control [0:15],
     output wire [31:0] status[0:15]
 );


### PR DESCRIPTION
Correct the Verilog wrapper for CI throughout examples. OutputInterp is only for CustomWrapper and so is removed from CI and CI+