### PR TITLE
Add examples for API docs page

### DIFF
--- a/matlab-api/README.md
+++ b/matlab-api/README.md
@@ -59,6 +59,15 @@ This example demonstrates how you can configure Custom Instrument, using Multi-I
 
 <<< @/docs/api/moku-examples/matlab-api/frequency_response_analyzer_plotting.m
 
+## GenInst
+
+### geninst_oscilloscope.m
+
+This example demonstrates how you can configure GenInst using
+Multi-Instrument Mode and output the result to the Oscilloscope.
+
+<<< @/docs/api/moku-examples/matlab-api/geninst_oscilloscope.m
+
 ## Gigabit Streamer
 
 ### gigabit_streamer_plotting.m

--- a/python-api/README.md
+++ b/python-api/README.md
@@ -87,6 +87,15 @@ in real-time.
 
 <<< @/docs/api/moku-examples/python-api/freq_response_analyzer_plotting.py
 
+## GenInst
+
+### geninst_oscilloscope.py
+
+This example demonstrates how you can configure GenInst using
+Multi-Instrument Mode and output the result to the Oscilloscope.
+
+<<< @/docs/api/moku-examples/python-api/geninst_oscilloscope.py
+
 ## Gigabit Streamer
 
 ### gigabit_streamer_plotting.py


### PR DESCRIPTION
Added GenInst examples for Python and MATLAB to API documentation site.